### PR TITLE
Fix(chart bug): "line" is not a registered controller

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.1.*",
-    "@kuzzleio/dashboard-builder": "0.6.*",
+    "@kuzzleio/dashboard-builder-frontend": ">= 0.6",
     "@kuzzleio/iot-console": "^3.0.0-rc6",
     "@kuzzleio/kuzzle-application-builder": ">= 0.9",
     "bootstrap-vue": "2.23.*",

--- a/apps/web/src/services/i18n.ts
+++ b/apps/web/src/services/i18n.ts
@@ -1,4 +1,4 @@
-import { locales as dashboardBuilderLocales } from '@kuzzleio/dashboard-builder';
+import { locales as dashboardBuilderLocales } from '@kuzzleio/dashboard-builder-frontend';
 import { locales as KIoTPLocales } from '@kuzzleio/iot-console';
 import { mergeLocaleMessages } from '@kuzzleio/kuzzle-application-builder';
 import defaultsDeep from 'lodash/defaultsDeep';

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -17,7 +17,7 @@ import {
 import {
   createDashboardsStoreModule,
   MODULE_NAME as DASHBOARDS,
-} from '@kuzzleio/dashboard-builder';
+} from '@kuzzleio/dashboard-builder-frontend';
 import { kuzzle, observer } from '@/services/kuzzle';
 
 Vue.use(Vuex);

--- a/apps/web/src/views/dashboards/Dashboard.vue
+++ b/apps/web/src/views/dashboards/Dashboard.vue
@@ -95,7 +95,7 @@ import {
   updateDashboard,
   EVENT_OPEN_NEW_WIDGET_MODAL,
   MODULE_NAME as DASHBOARDS,
-} from '@kuzzleio/dashboard-builder';
+} from '@kuzzleio/dashboard-builder-frontend';
 import { AbstractVueMixin, KTenantGetters, StoreNamespaceTypes } from '@kuzzleio/iot-console';
 import ShareIcon from '../../components/icons/ShareIcon.vue';
 import { kuzzle } from '../../services/kuzzle';

--- a/apps/web/src/views/dashboards/DashboardList.vue
+++ b/apps/web/src/views/dashboards/DashboardList.vue
@@ -48,7 +48,7 @@
 import { Component, Mixins, Watch } from 'vue-property-decorator';
 import { mapActions, mapGetters } from 'vuex';
 import { BaseListMixin, KTenantGetters, StoreNamespaceTypes } from '@kuzzleio/iot-console';
-import { MODULE_NAME as DASHBOARDS, DashboardsState } from '@kuzzleio/dashboard-builder';
+import { MODULE_NAME as DASHBOARDS, DashboardsState } from '@kuzzleio/dashboard-builder-frontend';
 import debounce from 'lodash/debounce';
 import DashbardListItem from '../../components/dashboards/DashboardListItem.vue';
 

--- a/apps/web/src/views/dashboards/factories.ts
+++ b/apps/web/src/views/dashboards/factories.ts
@@ -7,7 +7,7 @@ import {
   ChartWidgetForm,
   TableWidget,
   TableWidgetForm,
-} from '@kuzzleio/dashboard-builder';
+} from '@kuzzleio/dashboard-builder-frontend';
 
 export const kdbWidgets = [
   {


### PR DESCRIPTION
## Fix the "line" is not a registered controller
![image](https://user-images.githubusercontent.com/78204354/225640492-1a0cbb9c-882e-4def-abe1-a85fcdf5c46d.png)

The project was still using the old  `"@kuzzleio/dashboard-builder": ">= 0.6"` package instead of the 
`"@kuzzleio/dashboard-builder-frontend": ">= 0.6"`

<!--
  Please include a summary of the change, relevant motivation and context.
  Also, list any dependencies that are required for this change.
-->

### How should this be manually tested?

  - Step 1 : clone and run
  - Step 2 : create a tenant
  - Step 3 : try to create a chart 
